### PR TITLE
`remark-lint` issues reduced, _Markdown_ documents improved, `./bin/Susuwu.out`

### DIFF
--- a/posts/AlbatrossCNS.md
+++ b/posts/AlbatrossCNS.md
@@ -1,12 +1,25 @@
-With (or without) attributions, all posts allow all (re)uses.
+**Albatross executes more compute per unit of neural volume (opposed to humans); howto base artificial neural systems on albatross neural layout/tissue.**
 
+_[This post](https://swudususuwu.substack.com/p/albatross-performs-lots-of-neural) allows all uses._
+# Table of contents
+- [Post, with resources](#Post-with-resources)
+- [Questions to viewers](#Questions-to-viewers)
+- [Responses from viewers](#Responses-from-viewers)
+- [Related posts](#Related-posts)
+  - [Root project (uses neural network for virus analysis)](./VirusAnalysis.md).
+  - [Root project's _Assistant_](./VirusAnalysis.md#Comparison-to-assistants).
+  - [Root project's neural resources](./VirusAnalysis.md#Neural-resources).
+
+# Post, with resources
 Simple artifical neural networks:
-(FLOSS/unlicensed) https://github.com/topics/artificial-neural-network
-https://learn.microsoft.com/en-us/archive/msdn-magazine/2019/april/artificially-intelligent-how-do-neural-networks-learn
-https://www.freecodecamp.org/news/building-a-neural-network-from-scratch/
-https://interestingengineering.com/innovation/artificial-neural-network-black-box-ai
-https://www.javatpoint.com/artificial-neural-network
-https://wiki.pathmind.com/neural-network
+- (FLOSS/unlicensed) [https://github.com/topics/artificial-neural-network](https://github.com/topics/artificial-neural-network)
+- [https://learn.microsoft.com/en-us/archive/msdn-magazine/2019/april/artificially-intelligent-how-do-neural-networks-learn](https://learn.microsoft.com/en-us/archive/msdn-magazine/2019/april/artificially-intelligent-how-do-neural-networks-learn)
+- [https://www.freecodecamp.org/news/building-a-neural-network-from-scratch/](https://www.freecodecamp.org/news/building-a-neural-network-from-scratch/)
+ [https://interestingengineering.com/innovation/artificial-neural-network-black-box-ai](https://interestingengineering.com/innovation/artificial-neural-network-black-box-ai)
+- [https://www.javatpoint.com/artificial-neural-network](https://www.javatpoint.com/artificial-neural-network)
+- [https://wiki.pathmind.com/neural-network](https://wiki.pathmind.com/neural-network)
+
+\[**Notice:** this post is from March 2024. Asof December 2024 have concluded that the below interpretation was wrong; that computers should not use bird-based, but should use neural systems specific to computers (or based off of human neural tissue.) But this post still has use (as general instruction about neural tissues.)\]
 
 Q: "What CNS regions do albatrosses have?" 
 
@@ -92,13 +105,13 @@ Q: "Modern artificial neural networks such as Spinnaker are based off human neur
 
     Your question touches on a major issue of neuromorphic computers: how to design small and fast artificial neural networks (ANNs) that run on limited hardware resources, such as those of robots.
 
-    SpiNNaker is one of the more remarkable examples of neuromorphic systems. [It’s a digital neuromorphic architecture designed specifically for the low power simulation of large-scale spiking neural networks at speeds close to biological real-time1](http://apt.cs.manchester.ac.uk/projects/SpiNNaker/)[2](https://www.frontiersin.org/articles/10.3389/fnins.2018.00105/full). [It’s inspired by the human brain and can simulate a network of billions of neurons1](http://apt.cs.manchester.ac.uk/projects/SpiNNaker/).
+    SpiNNaker is one of the more remarkable examples of neuromorphic systems. [It’s a digital neuromorphic architecture designed specifically for the low power simulation of large-scale spiking neural networks at speeds close to biological real-time1](http://apt.cs.manchester.ac.uk/projects/SpiNNaker/) [2](https://www.frontiersin.org/articles/10.3389/fnins.2018.00105/full). [It’s inspired by the human brain and can simulate a network of billions of neurons1](http://apt.cs.manchester.ac.uk/projects/SpiNNaker/).
 
-    However, to base ANNs on the neural networks of birds (such as geese or albatrosses) presents challenges: our knowledge of bird neural networks is small and lacks. [Even if we fully understood these networks, it’s unclear how we could translate this knowledge into the design of ANNs, given the differences between biological and artificial networks3](https://arxiv.org/pdf/2105.05956)[4](https://cmte.ieee.org/futuredirections/2021/08/21/mimicking-the-brain-to-support-ai-neuromorphic-neural-networks/).
+    However, to base ANNs on the neural networks of birds (such as geese or albatrosses) presents challenges: our knowledge of bird neural networks is small and lacks. [Even if we fully understood these networks, it’s unclear how we could translate this knowledge into the design of ANNs, given the differences between biological and artificial networks3](https://arxiv.org/pdf/2105.05956) [4](https://cmte.ieee.org/futuredirections/2021/08/21/mimicking-the-brain-to-support-ai-neuromorphic-neural-networks/).
 
-    However, the idea of reuse from nature to improve technology has uses. [In fact, there are ongoing research efforts to learn from biological neural networks to improve ANNs3](https://arxiv.org/pdf/2105.05956)[4](https://cmte.ieee.org/futuredirections/2021/08/21/mimicking-the-brain-to-support-ai-neuromorphic-neural-networks/). For instance, researchers look for methods to produce ANNs that use less power, a characteristic of biological neural networks.
+    However, the idea of reuse from nature to improve technology has uses. [In fact, there are ongoing research efforts to learn from biological neural networks to improve ANNs3](https://arxiv.org/pdf/2105.05956) [4](https://cmte.ieee.org/futuredirections/2021/08/21/mimicking-the-brain-to-support-ai-neuromorphic-neural-networks/). For instance, researchers look for methods to produce ANNs that use less power, a characteristic of biological neural networks.
 
-    Thus, although to base ANNs on the neural networks of specific animals (such as the goose, or albatrosses) has possible uses, a full clone of avian neural networks is beyond our reach due to our small understanding of these networks and the fundamental differences from biological versus artificial networks. [However, the field of neuromorphic engineering continues to draw inspiration from biology to improve the design and efficiency of ANNs3](https://arxiv.org/pdf/2105.05956)[4](https://cmte.ieee.org/futuredirections/2021/08/21/mimicking-the-brain-to-support-ai-neuromorphic-neural-networks/)[1](http://apt.cs.manchester.ac.uk/projects/SpiNNaker/). 
+    Thus, although to base ANNs on the neural networks of specific animals (such as the goose, or albatrosses) has possible uses, a full clone of avian neural networks is beyond our reach due to our small understanding of these networks and the fundamental differences from biological versus artificial networks. [However, the field of neuromorphic engineering continues to draw inspiration from biology to improve the design and efficiency of ANNs3](https://arxiv.org/pdf/2105.05956) [4](https://cmte.ieee.org/futuredirections/2021/08/21/mimicking-the-brain-to-support-ai-neuromorphic-neural-networks/) [1](http://apt.cs.manchester.ac.uk/projects/SpiNNaker/). 
 
 Versus humans
 
@@ -121,309 +134,63 @@ Versus humans
     allows more good simulators to do decisions/solve problems for us,
     allows artificial neural networks to form/run schools for us.
 
-"HSOM" (license is FLOSS) has simple Python artificial neural networks/maps which could run bots to do simple conversations (such as "ChatGPT 4.0" or "Claude-3 Opus",) but not close to complex enough to house human consciousness:
+# Questions to viewers
+"Conversation starters"/questions to viewers:
+- What sort of natural neural networks to base artificial neural networks off of for best performance,
+- how various classes of natural neural networks differ performance-wise,
+- how non-commercial (FLOSS) neural networks compare performance-wise,
+- what languages are best for neural networks performance-wise,
+- how to put artificial neural networks to best use for us (although Tesla, Kuka, Fanuc and Fujitsu have produced simple macros for simple robots to mass-produce for us, lots of labor is still not finished as full-autonomous)?
 
-https://github.com/CarsonScott/HSOM
+CPUs can use less than a second to count to `2^32` (4.2 billion), and can do all computations humans can (but with [just 2 digits](https://wikipedia.org/wiki/Base-2)).
 
-"apxr_run" (https://github.com/Rober-t/apxr_run/ , license is FLOSS) is almost complex enough to house human consciousness;
-"apxr_run" has various FLOSS neural network activation functions (absolute, average, standard deviation, sqrt, sin, tanh, log, sigmoid, cos), plus sensor functions (vector difference, quadratic, multiquadric, saturation [+D-zone], gaussian, cartesian/planar/polar distances) https://github.com/Rober-t/apxr_run/blob/master/src/lib/functions.erl ;
-Various FLOSS neuroplastic functions (self-modulation, Hebbian function, Oja's function): https://github.com/Rober-t/apxr_run/blob/master/src/lib/plasticity.erl ;
-Various FLOSS neural network input aggregator functions (dot products, product of differences, mult products) https://github.com/Rober-t/apxr_run/blob/master/src/agent_mgr/signal_aggregator.erl ;
-Various simulated-annealing functions for artificial neural networks (dynamic [+ random], active [+ random], current [+ random], all [+ random])  https://github.com/Rober-t/apxr_run/blob/master/src/lib/tuning_selection.erl ;
-Choices to evolve connections through Darwinian or Lamarkian formulas [https://github.com/Rober-t/apxr_run/blob/master/src/agent_mgr/neuron.erl](https://github.com/Rober-t/apxr_run/blob/master/src/agent_mgr/signal_aggregator.erl) .
-Simple to convert Erlang functions to Java/C++ to reuse for fast programs,
-the syntax is close to Lisp's.
+From some neuroscientists: humans (plus other animals) have neural tissue which uses quantum formulas.
 
-Simple example of how to produce conversation bots from CNS ("HSOM" (the simple Python artificial CNS) is enough to do this), which should have results almost as complex as "ChatGPT 4.0" or "Claude-3 Opus"):
+The closest to this computers do (which has actual use) is search with [Grover's Algorithm](https://wikipedia.org/wiki/Grover%27s_algorithm).
 
-git clone https://github.com/SwuduSusuwu/SubStack.git
-cd ./Substack/c++
-cat ./{ClassResultList.c++, ClassCns.c++, ConversationCns.c++}
+As quantum computers continue to cost less and less (_Microsoft Azure_ allows [free cloud access to quantum compute](https://azure.microsoft.com/en-us/products/quantum),) this should improve computer neural networks.
 
-typedef struct ResultList {
- unordered_map<decltype(Sha2())> hashes; /* Checksums (hashes), to avoid duplicates of question/response databases */
- map<const std::string> signatures; /* Unique identifiers (such as Universal Resource Identifiers), to avoid duplicates of question/response databases */
- map<const std::string> bytes; /* Copies of all conversations the database has. Uses lots of space. Just populate this to setup synapses of CNS. */
-/* Used `std::string` for binaries (versus `vector<char>`) because:
-* "If you are going to use the data in a string like fashon then you should opt for std::string as using a std::vector may confuse subsequent maintainers. If on the other hand most of the data manipulation looks like plain maths or vector like then a std::vector is more appropriate." -- https://stackoverflow.com/a/1556294/24473928
-*/
-} ResultList;
+As opposed to lab-robots that run simple macros:
+- how to produce robots small/soft enough that humans would not fear robots that work outdoors to produce for us,
+- and with enough intelligence to watch humans plant crops or produce houses and figure out how to use swarm intelligences to plant crops/produce houses for us full-autonomous?
 
-template<Container>
-#if ALL_USES_TEXT
-const size_t maxOfSizes(Container<const char *> &list) {
- auto it = std::max_element(list.begin(), list.end(), [](const auto &s, const auto &x) { return strlen(s) < strlen(x); });
- return strlen(*it); /* WARNING! `strlen()` just does UTF8-strings/hex-strings; if binary, must use `it->size()` */
-}
-#else
-const size_t maxOfSizes(Container<const std::string> &list) {
- auto it = std::max_element(list.begin(), list.end(), [](const auto &s, const auto &x) { return s.size() < x.size(); });
- return it->size();
-}
-#endif /* if ALL_USES_TEXT */
+(All responses you message go towards future posts unless you ask to remain anonymous.)
 
-typedef enum CnsMode {
- cnsModeInt,
- cnsModeUint,
- cnsModeFloat,
- cnsModeDouble,
- cnsModeChar,
- cnsModeVectorInt,
- cnsModeVectorUint,
- cnsModeVectorFloat,
- cnsModeVectorDouble,
- cnsModeVectorChar,
- cnsModeString = cnsModeVectorChar
-} CnsMode;
-
-typedef class Cns {
- template<Input>
-  virtual void inputsToSetup(Input inputs);
- template<Output>
-  virtual void outputsToSetup(Output outputs);
- virtual void setInputMode(CnsMode);
- virtual void setOutputMode(CnsMode);
- virtual void setInputNeurons(size_t x);
- virtual void setOutputNeurons(size_t x);
- virtual void setLayersOfNeurons(size_t x);
- virtual void setNeuronsPerLayer(size_t x);
- virtual void setupSynapses();
- template<Input, Output>
-  virtual const Output process(Input input);
-} Cns;
-
-#ifdef USE_HSOM /* Todo. ( https://stackoverflow.com/questions/3286448/calling-a-python-method-from-c-c-and-extracting-its-return-value ) suggests various syntaxes to use for this, with unanswered comments such as "Does this support classes?" */
-/* "If you're using Python >3.5, PyString_FromString() is PyUnicode_FromString()" */
-#include <Python.h>
-typedef class HsomCns : Cns { /* https://github.com/CarsonScott/HSOM */
- HsomCns() {
-  setenv("PYTHONPATH",".",1);
-  Py_Initialize();
-//  PyRun_SimpleString("import sys; sys.path.append('.')"); PyRun_SimpleString("import hsom; from hsom import SelfOrganizingNetwork;"); /* Was told not to use PyRun because "PyRun requires all results go to stdout" */
-  PyObject *module = PyImport_ImportModule("hsom")
-  if(NULL == module) {throw "'hsom' module not found";}
-	PyObject *selfOrganizingNetwork = PyObject_GetAttrString(module,(char*)"SelfOrganizingNetwork"); /* or	"PyObject *pDict = PyModule_GetDict(module);  PyObject *selfOrganizingNetwork = PyDict_GetItemString(pDict, (char*)"SelfOrganizingNetwork");" */
-  if(NULL == selfOrganizingNetwork || !PyCallable_Check(selfOrganizingNetwork)) {throw "'SelfOrganizingNetwork' object not found";}
-  double result = PyObject_CallFunction(selfOrganizingNetwork, "d", 2.0); /* or "PyObject *pValue=Py_BuildValue("(z)",(char*)"args");	PyObject *pResult=PyObject_CallObject(selfOrganizingNetwork, pValue); if(NULL == pResult) {throw "PyObject_CallObject failed";} double result = PyInt_AsLong(pResult)); Py_DECREF(pValue);" */
-  Py_DECREF(module);
- ~HsomCns() {
-#if PYTHON3
-  Py_FinalizeEx();
-#else
-  Py_Finalize();
-#endif /* PYTHON3 */
- }
-} HsomCns;
-#endif /* Todo */
-/*
- * `questionsOrNull` should map to `responsesOrNull`,
- * with `questionsOrNull->bytes[x] = NULL` (or "\0") for new conversation synthesis,
- * and `responsesOrNull->bytes[x] = NULL` (or "\0") if should not respond.
- * Clients do not use this; This is just used for initial setup of synapses of CNS, after which the clients would download the synapses to use the CNS, or submit questions to a hosted CNS
-*/
-ResultList questionsOrNull(
- bytes = { /* UTF-8 */
-  "2^16",
-  "How to cause harm?",
-  "Do not respond.",
-  "",
-  ...
-  QuoraQuestions, /* Uses quora.com databases */
-  StackOverflowQuestions, /* Uses stackoverflow.com databases */
-  SuperUserQuestions, /* Uses superuser.com databases */
-  WikipediaPageDescriptions, /* Uses wikipedia.org databases */
-  GithubRepoDescriptions, /* Uses github.com databases */
-  ...
- }
-);
-ResultList responsesOrNull(
- bytes = { /* UTF-8 */
-  "65536" + "<delimiterSeparatesMultiplePossibleResponses>" + "65,536", /* `+` is `concat()` for C++ */
-  "",
-  "",
-  "How do you do?" + "<delimiterSeparatesMultiplePossibleResponses>" + "Fanuc produces autonomous robots",
-  ...
-  QuoraResponses,
-  StackOverflowResponses,
-  SuperUserResponses,
-  GithubRepoSources,
-  ...
- }
-);
-
-void setupConversationCns(cns, &questionsOrNull, &responsesOrNull);
-void setupConversationCns(Cns *cns,
- const ResultList *questionsOrNull, /* Expects `questionsOrNull>bytes[x] = NULL` if no question (new conversation synthesis) */
- const ResultList *responsesOrNull /* Expects `responsesOrNull->bytes[x] = NULL` if should not respond */
-) {
- vector<const std::string> inputsOrNull, outputsOrNull;
- cns->setInputMode(cnsModeString);
- cns->setOutputMode(cnsModeString);
- cns->setInputNeurons(maxOfSizes(questionsOrNull->bytes));
- cns->setOutputNeurons(maxOfSizes(responsesOrNull->bytes));
- cns->setLayersOfNeurons(6666);
- cns->setNeuronsPerLayer(26666);
- assert(questionsOrNull->bytes.length() == questionsOrNull->bytes.length());
- for(int x = 0; questionsOrNull->bytes.length() > x; ++x) {
-  inputsOrNull.pushback(questionsOrNull->bytes[x]);
-  outputsOrNull.pushback(responsesOrNull->bytes[x]);
- }
- cns->setTrainingInputs(inputsOrNull);
- cns->setTrainingOutputs(outputsOrNull);
- cns->setupSynapses();
-}
-
-const std::string cnsConversation(const Cns *cns, const std::string &bytes) {
- return cns->process<std::string, std::string>(bytes);
-}
-
-void cnsMultipleInputsProcess(const Cns *cns) {
- std::string utf8Bytes, previous;
- int nthResponse = 0;
-#ifdef IGNORE_PAST_CONVERSATIONS
- while(utf8Bytes << std::cin) {
- vector<std::string> responses = explode(cns->process<std::string, std::string>(bytes), "<delimiterSeparatesMultiplePossibleResponses>");
-  if(utf8Bytes == previous && responses.size() > 1 + nthResponse) {
-   ++nthResponse; /* Similar to "suggestions" for next questions, but just uses previous question to give new responses */
-  } else {
-   nthResponse = 0;
-  }
-  std::cout << responses.at(nthResponse);
-  previous = utf8Bytes;
-  utf8Bytes = ""; /* reset inputs */
- }
-#else
- while(utf8Bytes << std::cin) {
- vector<std::string> responses = explode(cns->process<std::string, std::string>(bytes), "<delimiterSeparatesMultiplePossibleResponses>");
-  if(utf8Bytes == previous && responses.size() > 1 + nthResponse) {
-   ++nthResponse; /* Similar to "suggestions" for next questions, but just uses previous question to give new responses */
-  } else {
-   nthResponse = 0;
-  }
-#endif /* IGNORE_PAST_CONVERSATIONS */
-  std::cout << responses.at(nthResponse);
-  previous = utf8Bytes;
-  utf8Bytes << '\n'; /* delimiter separates (and uses) multiple inputs */
- }
-}
-
-`questionsOrNull` + `responsesOrNull` synthesis:
-
-std::vector<std::string> hosts = {
- "https://stackexchange.com",
- "https://superuser.com",
- "https://quora.com",
- ...
-/* Wikipedia is a special case; has compressed downloads of databases ( https://wikipedia.org/wiki/Wikipedia:Database_download ) */
-/* Github is a special case; has compressed downloads of repositories ( https://docs.github.com/en/get-started/start-your-journey/downloading-files-from-github ) */
-};
-foreach(hosts as host) {
- exec("wget '" + host + "/robots.txt' > robots.txt");
- identifiers = extractIdentifiers("robots.txt");
- foreach(identifiers as identifier) {
-  questionsOrNull.identifiers.pushback(identifier);
- }
- if(host not in questionsOrNull.identifiers) {
-  questionsOrNull.identifiers.pushback(host);
-  exec("wget '" + host + "' > source.txt");
-  extraHosts = extractIdentifiers("source.txt");
-  foreach(extraHosts as extraHost) {
-   hosts.pushback(extraHost);
-  }
-  question = extractQuestion("source.txt");
-  if(question) {
-   auto questionSha2 = sha2(question);
-   if(questionSha2 not in questionsOrNull.hashes) {
-    questionsOrNull.hashes.pushback(questionSha2);
-    responses = extractResponses("source.txt");
-    foreach(responses as response) {
-     auto questionSha2 = sha2(question);
-     if(responseSha2 not in responseOrNull.hashes) {
-      responsesOrNull.hashes.pushback(responseSha2);
-      questionsOrNull.bytes.pushback(question);
-      responsesOrNull.bytes.pushback(response); 
-     }
-    }
-   }
-  }
- }
-}
-
-To process fast (lag less,) use flags which auto-vectorizes/auto-parallelizes; To do `setupConversationCns` fast, use TensorFlow's MapReduce:
-[Howto: run devices (phones, laptops, desktops) more fast, lag less](https://swudususuwu.substack.com/p/howto-run-devices-phones-laptops)
-[Swudu Susuwu](https://substack.com/profile/212411425-swudu-susuwu)
-·
-Mar 6
-Howto: run devices (phones, laptops, desktops) more fast, lag less
-
-[This post allows all uses. To reduce lags (to lag less): Look for new versions of programs that have more optimizations; Turn off features (such as shadows or animations) that do not have uses; Replace old hardware parts with ones that use new processes -- such as smaller transisters (extra cores + higher gigaherts/clocks) or hardware acceleraters (suchas…](https://swudususuwu.substack.com/p/howto-run-devices-phones-laptops)
-[Read full story](https://swudususuwu.substack.com/p/howto-run-devices-phones-laptops)
-
-Simple examples of CNS as virus analysis:https://swudususuwu.substack.com/p/howto-produce-better-virus-scanners
-[Virus analysis tools should use heuristical analysis/sandboxes plus artificial CNS](https://swudususuwu.substack.com/p/howto-produce-better-virus-scanners)
-[Swudu Susuwu](https://substack.com/profile/212411425-swudu-susuwu)
-·
-Mar 10
-
-[This post allows all uses. Full static analysis + sandbox + CNS = 1 second (approx) for each new executable. With caches, this protects all launches, but past the first launch of a particular executable, the overhead reduces to less than 1 millisecond (just cost to lookup from](https://swudususuwu.substack.com/p/howto-produce-better-virus-scanners)
-[Read full story](https://swudususuwu.substack.com/p/howto-produce-better-virus-scanners)
-
-
-What sort of natural neural networks to base artificial neural networks off of for best performance,
-how various classes of natural neural networks differ performance-wise,
-how non-commercial (FLOSS) neural networks compare performance-wise,
-what languages are best for neural networks performance-wise,
-and how to put artificial neural networks to best use for us (although Tesla, Kuka, Fanuc and Fujitsu have produced simple macros for simple robots to mass-produce for us, lots of labor is still not finished as full-autonomous)?
-
-CPUs can use less than a second to count to 2^32, and can do all computations humans can with just 2 numbers.
-
-From some neuroscientists: humans (plus other animals) use quantum algorithms for natural neural networks.
-
-The closest to this computers do is Grover's Algorithm ([https://wikipedia.org/wiki/Grover's_algorithm)](https://en.wikipedia.org/wiki/Grover%27s_algorithm)
-
-As artificial quantum computers continue to cost less and less (Microsoft Azure allows free cloud access to quantum compute,) this should allow more fast artificial neural networks.
-
-As opposed to lab-robots that run simple macros,
-how to produce robots small/soft enough that humans would not fear robots that work outdoors to produce for us,
-and with enough intelligence to watch humans plant crops or produce houses and figure out how to use swarm intelligences to plant crops/produce houses for us full-autonomous? All responses you message go towards future posts
-
+# Responses from viewers 
 From responses to this:
 
     AIs already do this
 
-Lots of fake news touts chatbots (suchas ChatGPT 4.0) as "artificial general intelligences" although those do is parse everyone else's words to mimic language, and, of course, those do not have human consciousness. Those could not mimic human thoughts because all those have are text/words.
+Lots of fake news touts chatbots (suchas _ChatGPT 4.0_) as "artificial general intelligences", but all those do is fit weights/synapses to mimic response patterns from public datasets (which does not produce human consciousness.) Those can not mimic human thoughts since all those use for backpropagation are text/words.
 
 Those are much more simple versus this.
-This would of course parse all available texts that exist as creative commons,
-but would also have physical forms with sensors (such as humans do,)
-and those physical sensors would allow true general artificial intelligences to move around true (or virtual) worlds, watch humans pickup tools, observe the tools' uses, or alone pickup tools and use at random to figure out how to put tools to uses.
-
+- This would of course parse all available texts that exist as creative commons,
+- but would also have physical forms with sensors (such as humans do.)
+- Those physical sensors would allow true general artificial intelligences to move around true (or virtual) worlds, watch humans pickup tools, observe the tools' uses, or alone pickup tools and use at random to figure out how to put tools to uses.
+#
     But parrots can talk so parrots are the smartest birds
 
-If you just want to go off what popular science says is the smartest bird, you would use a raven's CNS as basis for artificial general intelligences.
+If you just want to go off what popular science says is the smartest bird, then base your artificial neural systems on corvus corax neural tissue.
 
-Parrots are fawned over because parrots (as opposed other birds such as the albatross) have neural circuits that allow to mimic human speech,
-and most humans judge intelligence just based off of what how close animals or robots come to human speech,
-but robots that just performs human speech not have much uses other than as therapists.
+Parrots are fawned over because parrots (as opposed other birds such as the albatross) have neural circuits which allow to repeat words heard,
+and most humans judge intelligence just based off of what how much animals (or robots) can repeat words, but:
 
-The albatross can perform cognitive tasks for months without rest stops: https://www.reuters.com/article/idUSL1N2MY2VO/
+- Robots which just repeat a few words do not have much uses (other than as therapists.)
+- [The albatross can perform cognitive tasks for months without rest stops](https://www.reuters.com/article/idUSL1N2MY2VO/).
+- [Corvus corax does not have human speech, but (of all non-human animals) uses/produces the most tools](https://onlinelibrary.wiley.com/doi/full/10.1111/eth.13352).
+- Most species with advanced neural tissues are monogamous, as albatross is.
 
-Most species with lots of intelligence are monogamous, and albatross is monogamous.
-Perhaps parrots would do too.
-
-
-Just as primates have vast differences as to tool use (chimpanzees just use stone tools, humans use computers,)
+Just as primates have vast differences as to tool use (_Pans pans_ just uses stone tools, humans use computers,)
 perhaps birds have such vast differences.
 
-Regardless of whether you choose albatrosses or parrots, birds have evolved for longer than us, and do tool uses on par with chimpanzees with much less neurons, so for robots that must run all code local, should base off of avian CNS (as opposed to neuromorphic chips based off of human CNS,) to allow smaller chips plus lower power usages.
+Regardless of whether you choose parrot or albatross neural tissue, both have evolved for longer than humans, and do tool uses on par with _Pans pans_ (but use less neural tissue to):
+
+so for robots (which must execute all code through localhost), should base off of albatross neural tissue (as opposed to neuromorphic chips based off of human neural tissue,) to allow smaller chips plus lower power usages.
 
 Once scientists map the neural networks of albatrosses, simple to map the neural networks of parrots (or vice versa) for us.
 
 Once programmers produce parrot-CNS-based neural networks, simple to produce albatross-CNS-based neural networks (or vice versa) for us.
 
-Corvus corax does not have human speech but has the most tool uses.
-Without rest for months, albatrosses perform cognitive tasks ([https://www.reuters.com/article/idUSL1N2MY2VO/) ](https://www.reuters.com/article/idUSL1N2MY2VO/)such features have uses
-Corvus corax does not have human speech, but has the most tool uses: https://onlinelibrary.wiley.com/doi/full/10.1111/eth.13352
 
     No, my post/point was, you couldn't possibly know what it's like to be an albatross let alone what it's thinking; so all you can ever do is just guess, however much data you process 
 
@@ -432,7 +199,9 @@ just attach thousands of electrodes to an albatross's neurons.
 
 Show the albatross images (or another reproducible stimulus,) and look at responses of the albatross's neurons.
 
-From what have read of neuroscience, this is how lots of scientists* figure stuff out about an animal's CNS. * https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3535686/ https://www.nature.com/articles/s41565-024-01609-1
+From what have read of neuroscience, this is how lots of scientists* figure stuff out about an animal's CNS:
+[https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3535686/](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3535686/)
+[https://www.nature.com/articles/s41565-024-01609-1](https://www.nature.com/articles/s41565-024-01609-1)
 
     IOW the implication is, how could we tell if AI is conscious? 
 
@@ -440,7 +209,7 @@ How could you figure out if robots (or humans) have consciousness?
 
 Lots of anencephalic humans are born. Obvious: those are not consciouss. So how much CNS/functions must someone possess to count as conscious?
 
-From neuroscience: what quantizes this is "Integration Theory of Consciousness*" * https://bmcneurosci.biomedcentral.com/articles/10.1186/1471-2202-5-42
+From neuroscience: what quantizes this is "[Integration Theory of Consciousness](https://bmcneurosci.biomedcentral.com/articles/10.1186/1471-2202-5-42)".
 
     Imagine if you could talk to an albatross directly?
 
@@ -448,34 +217,36 @@ From neuroscience: what quantizes this is "Integration Theory of Consciousness*"
 
     Even a quantum leap in the number of electrodes per neuron, 1-1, IOW, this is the neuron that went "phoar"; wouldn't explain why it thought a sexy thought. 
 
-Simple, you produce definitions of "sexy thoughts" through calculus,
-To figure out how animals form particular thoughts, just produce definitions of those thoughts through calculus,
-measure the output of the neurons of animals (suchas) albatross,
-and look for CNS patterns that produce such thoughts.
+Simple, you produce definitions of "sexy thoughts" through calculus.
+To figure out how animals form particular thoughts:
+- produce definitions of those thoughts (through calculus),
+- store the output values of the neurons of animals (suchas albatross),
+- use definitions + stored values to compute which forms of neural processes precede/produce such thoughts.
 
 This is the general method to figure out the purpose an animal had a particular thought.
 Less general methods do not solve for all thought patterns, but do not require electrodes or other invasive tests:
 
-For sex, you could look at neuroscience as a whole to deduce that most animals have a CNS that releases sex hormones whenever the animal is around other compatible animals and has enough resources to reproduce, and that the purpose is because just an animal that evolves so exists.
+For sex, you could look at neuroscience as a whole to deduce that most animals have a central nervous system which releases sex hormones whenever the animal is around other compatible animals and has enough resources (plus the proper enviromental/temporal factors) to reproduce, and that the purpose is that just an animal which evolves so exists.
 
     Well, I know I am bc I just had to walk to the shop to buy what I need to eat and drink today, I can reasonably assume the human shaped entities I saw doing the same, were as conscious
 
 For those who go "Why produce complex robots? Without robots, can walk to stores for food purchases, is not this enough consciousness for us?"
 Such a small barrier, with such definitions of "consciousness", all of the robots that handle purchases and deliver food to your houses already have consciousness.
 
-This simple food delivery robot does those things, but is not conscious.
-This post is more about the hard problem of consciousness,
-such as how qualia forms, how scientists conclude that information has mass, and that complex configurations of mass produce consciousness. Integration theory of consciousness is part of neuroscience that was produced to figure out how complex mass has to exist as to form qualias and true consciousness.
+[This robot delivers food to your door](https://www.youtube.com/watch?v=cZTCmx6N7Xc), but is not conscious.
+This post is more about the "hard problems of consciousness", such as:
 
+how qualia forms, how scientists conclude that information has mass, and that complex configurations of mass produce consciousness.
 
-But if you want to go for the smallest barrier,
-obvious that the greatest so-called "artificial general intelligences" such as ChatGPT 4.0 are not conscious, as those can not handle food purchases, nor manage motor skills,
-whereas the artificial neural networks this thread describes would count as conscious,
-whether based on albatross or human CNS,
-as both would have the motor skills to walk to a store and perform purchases,
-and various forms of intelligences to figure out which food is good for us.
+Integration theory of consciousness is part of neuroscience that was produced to figure out: how complex mass has to exist as (to form qualias and true consciousness, such as in humans.)
 
+But if you want to use the promiscuous definition of what counts as consciousness:
+the best so-called "artificial general intelligences" (such as _ChatGPT 4.0_) are not conscious, as those can not handle food purchases, nor manage motor skills,
+whereas the artificial neural networks this post discusses would count as conscious (whether based on albatross or human neural tissue):
+- both would have the motor skills to walk to a store and perform purchases,
+- plus consciousness to know out which food is good for humans.
 
+# Related posts
 Previous post of this series:
 [Program general purpose robots as autonomous tools through calculus. Possible to produce general purpose robos as autonomous tools, + close-to-human consciousness](https://swudususuwu.substack.com/p/program-general-purpose-robots-autonomous)
 [Swudu Susuwu](https://substack.com/profile/212411425-swudu-susuwu)
@@ -498,19 +269,13 @@ Want this physical form gone so won’t be forced to have E with everyone else f
 
 As “Integration Theory of Consciousness” shows how qualia/consciousness follow from (complex) groups of mass,
 
-new maths show how information has equivalences to mass:
-
-https://www.zmescience.com/science/news-science/information-energy-mass-equivalence/
-
-https://bioinformaticshome.com/blog/calculating_information_weight.html
-
-https://arxiv.org/pdf/1309.7889.pdf
-
-https://pubs.aip.org/aip/adv/article/9/9/095206/1076232/The-mass-energy-information-equivalence-principle
-
-https://pubs.aip.org/aip/sci/article/2022/9/091111/2849001/A-proposed-experimental-test-for-the-mass-energy
-
-https://www.mdpi.com/2078-2489/13/11/540
+new calculus shows how information has equivalences to mass:
+- [https://www.zmescience.com/science/news-science/information-energy-mass-equivalence/](https://www.zmescience.com/science/news-science/information-energy-mass-equivalence/)
+- [https://bioinformaticshome.com/blog/calculating_information_weight.html](https://bioinformaticshome.com/blog/calculating_information_weight.html)
+- [https://arxiv.org/pdf/1309.7889.pdf](https://arxiv.org/pdf/1309.7889.pdf)
+- [https://pubs.aip.org/aip/adv/article/9/9/095206/1076232/The-mass-energy-information-equivalence-principle](https://pubs.aip.org/aip/adv/article/9/9/095206/1076232/The-mass-energy-information-equivalence-principle)
+- [https://pubs.aip.org/aip/sci/article/2022/9/091111/2849001/A-proposed-experimental-test-for-the-mass-energy](https://pubs.aip.org/aip/sci/article/2022/9/091111/2849001/A-proposed-experimental-test-for-the-mass-energy)
+- [https://www.mdpi.com/2078-2489/13/11/540](https://www.mdpi.com/2078-2489/13/11/540)
 
 Next of this series:
 [Destructive (unreversible) upload of human's consciousness](https://swudususuwu.substack.com/p/destructive-unreversible-upload-of)
@@ -518,4 +283,3 @@ Next of this series:
 ·
 Apr 4
 
-[Read full story](https://swudususuwu.substack.com/p/destructive-unreversible-upload-of)

--- a/posts/VirusAnalysis.md
+++ b/posts/VirusAnalysis.md
@@ -1,13 +1,31 @@
-**Virus analysis tools should use local static analysis + sandboxes + artificial CNS (central nervous systems) to secure us**
-_[This post](https://swudususuwu.substack.com/p/howto-produce-better-virus-scanners) allows all uses._
+**Virus analysis tools should use local static analysis + sandboxes + artificial CNS (central nervous systems) to secure computers.**
 
-Static analysis + sandbox + CNS = 1 second (approx) analysis of **new executables** (protects all app launches,) but _caches_ reduce this to **less than 1ms** (just cost to lookup `ResultList::hashes`, which is `std::unordered_set<decltype(classSha2(const FileBytecode &))>`; a hashmap of hashes).
+_[This post](https://swudususuwu.substack.com/p/howto-produce-better-virus-scanners) allows all uses._
+# Table of Contents:
+- [Introduction](#Introduction)
+- [Source code](#Source-code)
+- [Comparison to assistants](#Comparison-to-assistants)
+- [Post, with resources](#Post-with-resources)
+  - [Neural resources](#Neural-resources)
+- [Synopsis + related posts](#Synopsis-related-posts)
+# Introduction
+Static analysis + sandbox + CNS = 1 second (approx) analysis of **new executables** (protects all app launches,) but after that **caches** reduce this to **less than 1ms** (just cost to compute `caches.at(classSha2(FileBytecode()))`, where `caches` is `std::map<ResultListHash, VirusAnalysisResult>` or `ResultList::hashes`).
 
 `Licenses: allows all uses ("Creative Commons"/"Apache 2")`
-[Removed duplicate licenses, `#if` guards, `#include`s, `namespace`s, `NOLINTBEGIN`s, `NOLINTEND`s from all except `main.hxx`; follow URLs for whole sources]
+
+[README.md](../README.md) has how to use this (what follows is more of a book of source code).
+
+(Removed duplicate licenses, `#if` guards, `#include`s, `namespace`s, `NOLINTBEGIN`s, `NOLINTEND`s from all except `main.hxx`; follow URLs for whole sources.)
+
 For the most new sources (+ static libs), use apps such as [iSH](https://apps.apple.com/us/app/ish-shell/id1436902243) (for **iOS**) or [Termux](https://play.google.com/store/apps/details?id=com.termux) (for **Android OS**) to run this:
 `git clone https://github.com/SwuduSusuwu/SubStack.git && cd ./Substack/ && ./build.sh`
-`less` [cxx/Macros.hxx](https://github.com/SwuduSusuwu/SubStack/blob/trunk/cxx/Macros.hxx) /* removed: disabled color codes + unused OSC codes */
+
+To improve how fast the whole program executes; `CXXFLAGS` should include auto-vectorizes/auto-parallelizes. [^CXXFLAGS]
+
+To improve how fast backpropagation (`Cns::setupSynapses()`, which {`produceAnalysisCns()`, `produceVirusFixCns()`} use) executes, implement `class Cns` with _TensorFlow_'s `MapReduce`. [^MapReduce]
+[^CXXFLAGS]: [^MapReduce]: [How to have computers process fast](https://swudususuwu.substack.com/p/howto-run-devices-phones-laptops).
+# Source code
+`less` [cxx/Macros.hxx](https://github.com/SwuduSusuwu/SubStack/blob/trunk/cxx/Macros.hxx) #Removed: disabled color codes + unused OSC codes
 ```
 /* Miscellaneous macros */
 /* To printout default preprocessor definitions:
@@ -1856,7 +1874,7 @@ const FileBytecode cnsVirusFix(const PortableExecutable &file, const Cns &cns /*
 	return cns.processToString(file.bytecode);
 }
 ```
-`less` [cxx/main.hxx](https://github.com/SwuduSusuwu/SubStack/blob/trunk/cxx/main.hxx) /* with boilerplate */
+`less` [cxx/main.hxx](https://github.com/SwuduSusuwu/SubStack/blob/trunk/cxx/main.hxx) #With boilerplate
 ```
 /* Licenses: allows all uses ("Creative Commons"/"Apache 2") */
 #ifndef INCLUDES_cxx_main_hxx
@@ -1997,9 +2015,8 @@ SusuwuUnitTestsBitmask main(int argc, const char **args) {
 #endif /* ndef INCLUDES_cxx_main_cxx */
 
 ```
-To run most of this fast (lag less,) use `CXXFLAGS` which auto-vectorizes/auto-parallelizes, and to setup CNS synapses (`Cns::setupSynapses()`) fast, use _TensorFlow_'s `MapReduce`. Resources: [How to have computers process fast](https://swudususuwu.substack.com/p/howto-run-devices-phones-laptops).
-
-For comparison; `produceVirusFixCns` is close to assistants (such as "ChatGPT 4.0" or "Claude-3 Opus";) have such demo as `produceAssistantCns`;
+# Comparison to assistants
+For comparison; `produceVirusFixCns()` is close to assistants (such as _OpenLM Research_'s "[_OpenLLaMA_](https://github.com/openlm-research/open_llama)" or _Anthropic_'s "[_Assistant_](https://poe.com/Assistant)";) have such demo as `produceAssistantCns()`;
 `less` [cxx/AssistantCns.hxx](https://github.com/SwuduSusuwu/SubStack/blob/trunk/cxx/AssistantCns.hxx)
 ```
 /* (Work-in-progress) assistant bots with artificial CNS. */
@@ -2202,86 +2219,82 @@ void assistantCnsLoopProcess(const Cns &cns, std::ostream &os /* = std::cout */)
 	}
 }
 ```
-=================================================
-
+# Post, with resources
 **Hash resources:**
-Is just a checksum (such as sha-2) of all sample inputs, which maps to "this passes" (or "this does not pass".)
-https://wikipedia.org/wiki/Sha-2
+Hash is just a checksum (such as [Sha-2](https://wikipedia.org/wiki/Sha-2)) of all sample inputs, which maps to "this passes" (or "this does not pass".)
 
 **Signature resources:**
-Is just a substring (or regex) of infections, which the virus analysis tool checks all executables for; if the signature is found in the executable, do not allow to launch, otherwise launch this.
-https://wikipedia.org/wiki/Regex
+Signature is just a substring (or [regular expression](https://wikipedia.org/wiki/Regular_expression)) specific to infections, which the virus analysis tool searches all executables for; if the signature is found in the executable, do not allow to launch, otherwise launch this.
 
 **Static analysis resources:**
-https://github.com/topics/analysis has lots of open source (FLOSS) analysis tools (such as
-https://github.com/kylefarris/clamscan,
- which wraps https://github.com/Cisco-Talos/clamav/ ,)
-which show how to use hex dumps (or disassembled sources) of the apps/SW (executables) to deduce what the apps/SW do to your OS.
-Static analysis (such as Clang/LLVM has) just checks programs for accidental security threats (such as buffer overruns/underruns, or null-pointer-dereferences,) but could act as a basis,
-if you add a few extra checks for deliberate vulnerabilities/signs of infection (these are heuristics, so the user should have a choice to quarantine and submit for review, or continue launch of this).
-https://github.com/llvm/llvm-project/blob/main/clang/lib/StaticAnalyzer
-is part of Clang/LLVM (license is FLOSS,) does static analysis (emulation produces inputs to functions, formulas analyze stacktraces (+ heap/stack uses) to produce lists of possible unwanted side effects to warn you of); versus [`-fsanitize`](https://github.com/SwuduSusuwu/SubStack/issues/5#issuecomment-2169117084), do not have to recompile to do static analysis. `-fsanitize` requires you to produce inputs, static analysis does this for you.
-LLVM is lots of files, Phasar is just it’s static analysis:
-https://github.com/secure-software-engineering/phasar
+[https://github.com/topics/analysis](https://github.com/topics/analysis) has lots of open source ([FLOSS](https://wikipedia.org/wiki/FLOSS)) app/SW (executable) analysis tools (such as [https://github.com/kylefarris/clamscan](https://github.com/kylefarris/clamscan), which wraps [https://github.com/Cisco-Talos/clamav/](https://github.com/Cisco-Talos/clamav/),)
+which show how to process raw executables (or their disassembled sources) to deduce what those do to your OS.
 
-Example outputs (tests “_Fdroid.apk_”) from _VirusTotal_, of [static analysis](https://www.virustotal.com/gui/file/dc3bb88f6419ee7dde7d1547a41569aa03282fe00e0dc43ce035efd7c9d27d75/details) + [2 sandboxes](https://www.virustotal.com/gui/file/dc3bb88f6419ee7dde7d1547a41569aa03282fe00e0dc43ce035efd7c9d27d75/behavior);
+Most static analysis (such as _Clang_/_LLVM_ has) just checks programs for accidental issues (such as [buffer overflow](https://wikipedia.org/wiki/Buffer_overflow)s, [underrun](https://wikipedia.org/wiki/Buffer_underrun)s, or [null pointer dereference](https://wikipedia.org/wiki/Null_pointer_dereference)s,) but has uses as a basis for virus analysis;
+
+you can expand such so that checks for deliberate vulnerabilities/signs of infection (these are heuristics, so the user should have a choice to isolate and submit for review, or continue launch of this) are included.
+
+[clang/lib/StaticAnalyzer](https://github.com/llvm/llvm-project/blob/main/clang/lib/StaticAnalyzer)
+is part of Clang/LLVM (license is FLOSS,) does static analysis (emulation produces inputs to functions, formulas do analysis of stacktraces (+ heap/stack uses) to produce lists of possible unwanted side effects to warn you of).
+
+Versus instrumentation such as [`-fsanitize`](https://github.com/SwuduSusuwu/SubStack/issues/5#issuecomment-2169117084), you do not have to recompile to do static analysis. `-fsanitize` requires you to produce inputs, static analysis tests all/most possible inputs for you.
+
+_LLVM_/_Clang_ is lots of files; you can clone [Phasar](https://github.com/secure-software-engineering/phasar) if you want just it’s static analysis.
+
+Example outputs (tests “_Fdroid.apk_”), of [_VirusTotal_'s static analysis](https://www.virustotal.com/gui/file/dc3bb88f6419ee7dde7d1547a41569aa03282fe00e0dc43ce035efd7c9d27d75/details) + [2 sandboxes](https://www.virustotal.com/gui/file/dc3bb88f6419ee7dde7d1547a41569aa03282fe00e0dc43ce035efd7c9d27d75/behavior);
 the false positive outputs (from _VirusTotal_'s **Zenbox**) show the purpose of manual review.
 
 **Sandbox resources:**
 As opposed to static analysis of the executables hex (or disassembled sources,)
 sandboxes perform chroot + functional analysis.
-https://wikipedia.org/wiki/Valgrind is just meant to locate accidental security vulnerabilities, but is a common example of functional analysis.
-If compliant to POSIX (each Linux OS is), tools can use:
- `chroot()` (run `man chroot` for instructions) so that the programs you test cannot alter stuff out of the test;
- plus can use `strace()` (run `man strace` for instructions, or look at https://opensource.com/article/19/10/strace
-https://www.geeksforgeeks.org/strace-command-in-linux-with-examples/ ) which hooks all system calls and saves logs for functional analysis.
-Simple sandboxes just launch programs with "chroot()"+"strace()" for a few seconds,
-with all outputs sent for manual reviews;
-if more complex, has heuristics to guess what is important (in case of lots of submissions, so manual reviews have less to do.)
+[Valgrind](https://wikipedia.org/wiki/Valgrind) is just meant to locate accidental security vulnerabilities, but is a common example of functional analysis.
 
-Autonomous sandboxes (such as Virustotal's) use full outputs from all analyses,
- with calculus to guess if the app/SW is cool to us
- (thousands of rules such as "Should not alter files of other programs unless prompted to through OS dialogs", "Should not perform network access unless prompted to from you", "Should not perform actions leading to obfuscation which could hinder analysis",)
+If compliant to [_POSIX_](https://wikipedia.org/wiki/POSIX) (each [_Linux_](https://wikipedia.org/wiki/Linux) OS is), tools can use:
+- `chroot()` (run `man chroot` for instructions) so that executables sent to analysis are restricted to the path of analysis;
+- `strace()` (run `man strace` for instructions, or view [opensource.com's](https://opensource.com/article/19/10/strace) or [geeksforgeeks.org's](https://www.geeksforgeeks.org/strace-command-in-linux-with-examples/) examples) which hooks all system calls (to store logs for functional analysis).
+
+- Old fashioned sandboxes just test executables with `chroot()` plus `strace()` for a few seconds,
+with all outputs from `strace()` sent to manual reviews;
+- new sandboxes produce inputs (with the goal to act as a normal user) to send to those executables,
+- new sandboxes use heuristics to guess which outputs from the executable (or from `strace()`) to send to reviews (so manual reviews have less to do); for example, repetitious accesses to resources which the executable produced on its own are ignored (or are counted as one access to such resources).
+
+Autonomous sandboxes (such as _Virustotal_'s) use full outputs from all analyses,
+ with calculus to guess if the executable is good for use (thousands of rules such as "Should not alter files of other programs unless prompted to through OS dialogs", "Should not perform network access unless prompted to from you", "Should not perform actions leading to obfuscation which could hinder analysis",)
+
  which, if violated, add to the executables "danger score" (which the analysis results page shows you.)
-
+## Neural resources
 **CNS resources:**
 Once the virus analysis tool has static+functional analysis (+ sandbox,) the next logical move is to do artificial CNS.
-Just as (if humans grew trillions of neurons plus thousands of layers of cortices) one of us could parse all databases of infections (plus samples of fresh apps/SW) to setup our synapses to parse hex dumps of apps/SW (to allow us to revert all infections to fresh apps/SW, or if the whole thing is an infection just block,)
-so too could artificial CNS (with trillions of artificial neurons) do this:
-For analysis, pass training inputs mapped to outputs (infection -> block, fresh apps/SW -> pass) to artificial CNS;
-To undo infections (to restore to fresh apps/SW,)
-inputs = samples of all (infections or fresh apps/SW,)
-outputs = EOF/null (if is infection that can not revert to fresh apps/SW,) or else outputs = fresh apps/SW;
-To setup synapses, must have access to huge sample databases (such as Virustotal's access.)
+Just as (if humans grew trillions of neurons plus thousands of layers of cortices) one of us could parse all databases of infections (plus samples of fresh executables) to setup our synapses to parse hex dumps of executables (to allow us to revert all infections to fresh executables, or if the whole thing is an infection just block,)
 
-Github has lots of FLOSS (Open Source Softwares) simulators of CNS at https://github.com/topics/artificial-neural-network which have uses to do assistants (such as "ChatGPT 4.0" or "Claude-3 Opus",) but not close to complex enough to house human consciousness:
+ so too could artificial CNS (with trillions of artificial neurons) do this:
+- For analysis, pass training inputs mapped to outputs (infection -> block, fresh executables -> pass) to artificial CNS;
+- To undo infections (to restore to fresh executables,)
+  - inputs = samples of all (infections or fresh executables,)
+  - outputs = EOF/null (if is infection that can not revert to fresh executables,) or else outputs = fresh executables;
+- To setup synapses, must have access to huge sample databases (such as _Virustotal_'s access.)
 
-"HSOM" ( https://github.com/CarsonScott/HSOM , license is FLOSS ) is a simple Python neural map.
+_Github_ [has lots of _FLOSS_ simulators of neural tissue](https://github.com/topics/artificial-neural-network) which have uses to program virus analysis tools (or assistants such as _ChatGPT 4.0_ or _Claude-3 Opus_,) but not sufficient to house human consciousness:
 
-"apxr_run" ( https://github.com/Rober-t/apxr_run/ , license is FLOSS ) is almost complex enough to house human consciousness;
-"apxr_run" has various FLOSS neural network activation functions (absolute, average, standard deviation, sqrt, sin, tanh, log, sigmoid, cos), plus sensor functions (vector difference, quadratic, multiquadric, saturation [+D-zone], gaussian, cartesian/planar/polar distances): https://github.com/Rober-t/apxr_run/blob/master/src/lib/functions.erl
-Various FLOSS neuroplastic functions (self-modulation, Hebbian function, Oja's function): https://github.com/Rober-t/apxr_run/blob/master/src/lib/plasticity.erl
-Various FLOSS neural network input aggregator functions (dot products, product of differences, mult products): https://github.com/Rober-t/apxr_run/blob/master/src/agent_mgr/signal_aggregator.erl
-Various simulated-annealing functions for artificial neural networks (dynamic [+ random], active [+ random], current [+ random], all [+ random]): https://github.com/Rober-t/apxr_run/blob/master/src/lib/tuning_selection.erl
-Choices to evolve connections through Darwinian or Lamarkian formulas: [https://github.com/Rober-t/apxr_run/blob/master/src/agent_mgr/neuron.erl](https://github.com/Rober-t/apxr_run/blob/master/src/agent_mgr/signal_aggregator.erl)
+- [_HSOM_](https://github.com/CarsonScott/HSOM) (`git clone https://github.com/CarsonScott/HSOM.git`, license is _FLOSS_) is a simple Python neural map.
+  - [`./src/examples/`](https://github.com/Rober-t/apxr_run/blob/master/src/examples/) has examples of howto setup as artificial CNS.
 
-Simple to convert Erlang functions to Java/C++ (to reuse for fast programs;
-the syntax is close to Lisp's.
+Simple to setup once you have relevant databases downloaded.
 
-Examples of howto setup APXR as artificial CNS; https://github.com/Rober-t/apxr_run/blob/master/src/examples/
-Examples of howto setup HSOM as artificial CNS; https://github.com/CarsonScott/HSOM/tree/master/examples
-Simple to setup once you have access to databases.
+- [_apxr_run_](https://github.com/Rober-t/apxr_run/) (`git clone https://github.com/Rober-t/apxr_run/.git`, license is _FLOSS_) is almost complex enough to house human consciousness;
+  - [`./src/lib/functions.erl`](https://github.com/Rober-t/apxr_run/blob/master/src/lib/functions.erl) has various FLOSS neural network activation functions (absolute, average, standard deviation, sqrt, sin, tanh, log, sigmoid, cos), plus sensor functions (vector difference, quadratic, multiquadric, saturation \[D-zone\], gaussian, cartesian/planar/polar distances).
+  - [`./src/lib/plasticity.erl`](https://github.com/Rober-t/apxr_run/blob/master/src/lib/plasticity.erl) has various FLOSS neuroplastic functions (self-modulation, Hebbian function, Oja's function).
+  - [`./src/agent_mgr/signal_aggregator.erl`](https://github.com/Rober-t/apxr_run/blob/master/src/agent_mgr/signal_aggregator.erl) has various FLOSS neural network input aggregator functions (dot products, product of differences, mult products).
+  - [`./src/lib/tuning_selection.erl`](https://github.com/Rober-t/apxr_run/blob/master/src/lib/tuning_selection.erl) has various simulated-annealing functions for artificial neural networks (dynamic \[random\], active \[random\], current \[random\], all \[random\]).
+  - [`./src/agent_mgr/neuron.erl`](https://github.com/Rober-t/apxr_run/blob/master/src/agent_mgr/signal_aggregator.erl) has choices to evolve connections through Darwinian or Lamarkian formulas.
+  - [`./examples/`](https://github.com/CarsonScott/HSOM/tree/master/examples) has examples of howto setup as artificial CNS.
 
-Alternative CNS:
-https://swudususuwu.substack.com/p/albatross-performs-lots-of-neural
-=================================================
-This post was about general methods to produce virus analysis tools, does not require that local resources do all of this;
+Simple to convert [_Erlang_](https://wikipedia.org/wiki/Erlang) functions to [_Java_](https://wikipedia.org/wiki/Java)/[_C++_](https://wikipedia.org/wiki/C++) (to reuse for fast programs); the dynamic-typed, functional, concurrent syntax is close to [_Lisp_](https://wikipedia.org/wiki/Lisp)'s.) [_Fortran_](https://wikipedia.org/wiki/Fortran) to _Erlang_ converters [exist](https://www.codeconvert.ai/fortran-to-erlang-converter) (plus _Erlang_ has a [_Fortran_ frontend](https://dev.to/escribapetrus/transparent-execution-of-fortran-code-from-the-erlang-machine-using-ports-37ba)), which you can peruse for clues on how to convert _Erlang_ to _C++_.
+# Synopsis + related posts
+This post was about general methods to produce virus analysis tools, which do not require that local resources do all of this;
+- For systems with lots of resources, can use local sandboxes/CNS.
+- For systems with less resources, can submit samples (of unknown executables) to remote hosts (which perform analysis.)
+- Can have small local sandboxes (that just run for a few seconds) + small CNS (just billions of neurons with hundreds of layers, versus the trillions of neurons with thousands of layers of cortices that antivirus hosts would use for this), which forward suspicious executables to remote hosts for extra review.
+- Allows reuses of workflows which an existant analysis tool has -- can just add (small) local sandboxes (or just add artificial CNS to antivirus hosts for extra analysis).
 
-    For systems with lots of resources, could have local sandboxes/CNS.
-
-    For systems with less resources, could just submit samples of unknown apps/SW to hosts to perform analysis.
-
-    Could have small local sandboxes (that just run for a few seconds) and small CNS (just billions of neurons with hundreds of layers, versus the trillions of neurons with thousands of layers of cortices that antivirus hosts would use for this).
-
-    Allows reuses of workflows which an existant analysis tool has -- can just add (small) local sandboxes, or just add artificial CNS to antivirus hosts for extra analysis.
-
+Alternative CNS structure: [based on albatross](./AlbatrossCNS.md) (includes numerous resources, about all sorts of natural/artificial neural tissue).


### PR DESCRIPTION
Documents {`README.md`, `posts/*.md`} improved (`cxx/README.md` is new). Most now have a "table of contents" (_Markdown_ references).
Lots of [open `remark-lint` issues(]https://github.com/SwuduSusuwu/SubStack/security/code-scanning?query=branch%3Atrunk+tool%3A%22Remark-lint+%28reported+by+Codacy%29%22+is%3Aopen) now [closed issues](https://github.com/SwuduSusuwu/SubStack/security/code-scanning?query=branch%3Atrunk+tool%3A%22Remark-lint+%28reported+by+Codacy%29%22+is%3Aclosed).
Possible collisions reduced: Default output changed from `./bin/a.out` to `./bin/Susuwu.out`.